### PR TITLE
EPMRPP-78961 || Feature create index template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apk --no-cache add curl bash && \
 
 ADD "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" /wait-for-it.sh
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh && chmod +xr /wait-for-it.sh
+COPY index-template-setup.sh /index-template-setup.sh
+RUN chmod +x /entrypoint.sh && chmod +xr /wait-for-it.sh && chmod +x /index-template-setup.sh
 
 COPY migrations/ /migrations/
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Migration scripts for ReportPortal
 
+## Description
+
+In this repository, you will find the migration scripts for ReportPortal.
+These scripts are utilized to update the database schema and generate an index
+template for OpenSearch.
+
 ### Usage
 
 #### Update to latest revision
@@ -16,3 +22,19 @@ docker-compose run --rm migrations down
 ```sh
 docker-compose run --rm migrations down N
 ```
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+|POSTGRES_SSLMODE|SSL mode for Postgres connection|
+|POSTGRES_USER|Postgres user|
+|POSTGRES_PORT|Postgres port|
+|POSTGRES_PASSWORD|Postgres password|
+|POSTGRES_SERVER|Postgres server|
+|POSTGRES_DB|Postgres database|
+|OS_HOST|Opensearch host|
+|OS_PORT|Opensearch port|
+|OS_PROTOCOL|Opensearch protocol. If security plugin is enabled, use https|
+|OS_USER|Opensearch user. If the security plugin is disabled, keep it empty|
+|OS_PASSWORD|Opensearch password. If the security plugin is disabled, keep it empty|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,23 @@
 version: '2'
 services:
+  migrations:
+    build: .
+    depends_on:
+      - postgres
+      - opensearch
+    environment:
+      POSTGRES_SSLMODE: disable #require
+      POSTGRES_USER: rpuser
+      POSTGRES_PORT: 5432
+      POSTGRES_PASSWORD: rppass
+      POSTGRES_SERVER: postgres
+      POSTGRES_DB: reportportal
+      OS_HOST: opensearch
+      OS_PORT: 9200
+      OS_PROTOCOL: http # If security plugin is enabled, change to https
+      OS_USER: # If security plugin is enabled use 'admin' as username
+      OS_PASSWORD: # If security plugin is enabled use 'admin' as password
+
   postgres:
     image: postgres:12-alpine
     environment:
@@ -18,44 +36,40 @@ services:
 #      max-size: "50M"
 #      max-file: "1"
 
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
+  opensearch:
+    image: opensearchproject/opensearch:latest
+    environment:
+      - discovery.type=single-node # Disable network discovery for single-node cluster
+      - bootstrap.memory_lock=true # Disable JVM heap memory swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # Set min and max JVM heap sizes to at least 50% of system RAM
+      - "DISABLE_INSTALL_DEMO_CONFIG=true" # Prevents execution of bundled demo script which installs demo certificates and security configurations to OpenSearch
+      - "DISABLE_SECURITY_PLUGIN=true" # Disables Security plugin
     volumes:
-      - ./data/elasticsearch:/usr/share/elasticsearch/data
-    environment:
-      - "ES_JAVA_OPTS=-Dlog4j2.formatMsgNoLookups=true"
-      - "bootstrap.memory_lock=true"
-      - "discovery.type=single-node"
-      - "logger.level=INFO"
-      - "xpack.security.enabled=true"
-      - "ELASTIC_PASSWORD=elastic1q2w3e"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
+      - ./data/opensearch:/usr/share/opensearch/data # Creates volume called opensearch and mounts it to the container
     ports:
-      - "9200:9200"
-    healthcheck:
-      test: [ "CMD", "curl","-s" ,"-f", "http://elastic:elastic1q2w3e@localhost:9200/_cat/health" ]
-    restart: always
+      - 9200:9200 # REST API
+      - 9600:9600 # Performance Analyzer
 
-  migrations:
-    build: .
-    depends_on:
-      - postgres
-      - elasticsearch
-    environment:
-      POSTGRES_SSLMODE: disable #require
-      POSTGRES_USER: rpuser
-      POSTGRES_PORT: 5432
-      POSTGRES_PASSWORD: rppass
-      POSTGRES_SERVER: postgres
-      POSTGRES_DB: reportportal
-      ES_HOST: elasticsearch
-      ES_PORT: 9200
-      ES_USER: elastic
-      ES_PASSWORD: elastic1q2w3e
-
+  # elasticsearch:
+  #   image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
+  #   volumes:
+  #     - ./data/elasticsearch:/usr/share/elasticsearch/data
+  #   environment:
+  #     - "ES_JAVA_OPTS=-Dlog4j2.formatMsgNoLookups=true"
+  #     - "bootstrap.memory_lock=true"
+  #     - "discovery.type=single-node"
+  #     - "logger.level=INFO"
+  #     - "xpack.security.enabled=true"
+  #     - "ELASTIC_PASSWORD=elastic1q2w3e"
+  #   ulimits:
+  #     memlock:
+  #       soft: -1
+  #       hard: -1
+  #     nofile:
+  #       soft: 65536
+  #       hard: 65536
+  #   ports:
+  #     - "9200:9200"
+  #   healthcheck:
+  #     test: [ "CMD", "curl","-s" ,"-f", "http://elastic:elastic1q2w3e@localhost:9200/_cat/health" ]
+  #   restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: rppass
       POSTGRES_DB: reportportal
     volumes:
-      - reportportal-database:/var/lib/postgresql/data
+      - ./data/postgres:/var/lib/postgresql/data
     restart: on-failure
   # If you need to access the DB locally. Could be a security risk to expose DB.
     ports:
@@ -18,10 +18,35 @@ services:
 #      max-size: "50M"
 #      max-file: "1"
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
+    volumes:
+      - ./data/elasticsearch:/usr/share/elasticsearch/data
+    environment:
+      - "ES_JAVA_OPTS=-Dlog4j2.formatMsgNoLookups=true"
+      - "bootstrap.memory_lock=true"
+      - "discovery.type=single-node"
+      - "logger.level=INFO"
+      - "xpack.security.enabled=true"
+      - "ELASTIC_PASSWORD=elastic1q2w3e"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: [ "CMD", "curl","-s" ,"-f", "http://elastic:elastic1q2w3e@localhost:9200/_cat/health" ]
+    restart: always
+
   migrations:
     build: .
     depends_on:
       - postgres
+      - elasticsearch
     environment:
       POSTGRES_SSLMODE: disable #require
       POSTGRES_USER: rpuser
@@ -29,6 +54,8 @@ services:
       POSTGRES_PASSWORD: rppass
       POSTGRES_SERVER: postgres
       POSTGRES_DB: reportportal
+      ES_HOST: elasticsearch
+      ES_PORT: 9200
+      ES_USER: elastic
+      ES_PASSWORD: elastic1q2w3e
 
-volumes:
-  reportportal-database:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,20 @@
 #!/bin/sh
 
-if [ ! -z $POSTGRES_PASSWORD_FILE ]; then
-  export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
-fi
+if [ ! -z $OS_HOST ]; then
 
-exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@" \
-  & exec /wait-for-it.sh $ES_HOST:$ES_PORT -- ./index-template-setup.sh
+  if [ ! -z $POSTGRES_PASSWORD_FILE ]; then
+    export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
+  fi
+
+  exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@" \
+    & exec /wait-for-it.sh $OS_HOST:$OS_PORT --strict -- ./index-template-setup.sh
+
+else
+
+  if [ ! -z $POSTGRES_PASSWORD_FILE ]; then
+    export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
+  fi
+
+  exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@"
+
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,5 @@ if [ ! -z $POSTGRES_PASSWORD_FILE ]; then
   export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
 fi
 
-exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@"
+exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@" \
+  & exec /wait-for-it.sh $ES_HOST:$ES_PORT -- ./index-template-setup.sh

--- a/index-template-setup.sh
+++ b/index-template-setup.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+## Elasticsearch URL
+#ES_HOST="localhost:9200"
+#
+## Elasticsearch user
+#ES_USER="elastic"
+#
+## Elasticsearch user password
+#ES_PASSWORD="elastic1q2w3e"
+
+# Index template name
+TEMPLATE_NAME="test"
+
+# JSON data for the index template
+TEMPLATE_DATA='
+{
+  "index_patterns": ["test-*-*"],
+  "data_stream": {},
+  "priority": 100,
+  "template":{
+    "settings": {
+      "index": {
+        "query": {
+          "default_field": [
+            "message"
+          ]
+        }
+      }
+    },
+    "mappings": {
+      "properties": {
+        "timestamp": {
+          "type": "date"
+        },
+        "message": {
+          "type": "text"
+        }
+      }
+    }
+  }
+}
+'
+
+# Check if the template exists
+response=$(curl -s -o /dev/null -w "%{http_code}" --location --head "$ES_HOST/_index_template/$TEMPLATE_NAME" -u $ES_USER:$ES_PASSWORD)
+
+case $response in
+404)
+    # Create the template
+    curl -X PUT "$ES_HOST/_index_template/$TEMPLATE_NAME" -H "Content-Type: application/json" -d "$TEMPLATE_DATA" -u $ES_USER:$ES_PASSWORD
+    echo "Template $TEMPLATE_NAME created."
+  ;;
+200)
+  echo "Template $TEMPLATE_NAME already exists."
+  ;;
+401)
+  echo  "Unable to authenticate user $ELASTICSEARCH_USER for REST request."
+  ;;
+000)
+  echo "Connection error. Host $ELASTICSEARCH_URL"
+  ;;
+*)
+  echo "$response"
+  echo "Undefine error."
+  ;;
+esac

--- a/index-template-setup.sh
+++ b/index-template-setup.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 
-## Elasticsearch URL
-#ES_HOST="localhost:9200"
-#
-## Elasticsearch user
-#ES_USER="elastic"
-#
-## Elasticsearch user password
-#ES_PASSWORD="elastic1q2w3e"
+# # Elasticsearch URL
+# ES_HOST="localhost"
+
+# # Elasticsearch port
+# ES_PORT="9200"
+
+# # Elasticsearch user
+# ES_USER="elastic"
+
+# # Elasticsearch user password
+# ES_PASSWORD="elastic1q2w3e"
 
 # Index template name
-TEMPLATE_NAME="test"
+TEMPLATE_NAME="logs"
 
 # JSON data for the index template
 TEMPLATE_DATA='
 {
-  "index_patterns": ["test-*-*"],
+  "index_patterns": ["logs-*-*"],
   "data_stream": {},
   "priority": 100,
   "template":{
@@ -43,25 +46,25 @@ TEMPLATE_DATA='
 '
 
 # Check if the template exists
-response=$(curl -s -o /dev/null -w "%{http_code}" --location --head "$ES_HOST/_index_template/$TEMPLATE_NAME" -u $ES_USER:$ES_PASSWORD)
+response=$(curl -s -o /dev/null -w "%{http_code}" --location --head "$ES_HOST:$ES_PORT/_index_template/$TEMPLATE_NAME" -u $ES_USER:$ES_PASSWORD)
 
 case $response in
 404)
     # Create the template
-    curl -X PUT "$ES_HOST/_index_template/$TEMPLATE_NAME" -H "Content-Type: application/json" -d "$TEMPLATE_DATA" -u $ES_USER:$ES_PASSWORD
-    echo "Template $TEMPLATE_NAME created."
+    curl -X PUT "$ES_HOST:$ES_PORT/_index_template/$TEMPLATE_NAME" -H "Content-Type: application/json" -d "$TEMPLATE_DATA" -u $ES_USER:$ES_PASSWORD
+    echo "Template '$TEMPLATE_NAME' created."
   ;;
 200)
-  echo "Template $TEMPLATE_NAME already exists."
+  echo "Template '$TEMPLATE_NAME' already exists."
   ;;
 401)
-  echo  "Unable to authenticate user $ELASTICSEARCH_USER for REST request."
+  echo  "Unable to authenticate user '$ES_USER' for REST request."
   ;;
 000)
-  echo "Connection error. Host $ELASTICSEARCH_URL"
+  echo "Can't connect to serviver on '$ES_HOST:$ES_PORT'."
   ;;
 *)
   echo "$response"
-  echo "Undefine error."
+  echo "Something went wrong."
   ;;
 esac


### PR DESCRIPTION
Add logic to migrations which:

* When an OS_HOST environment is added, the `index-template-setup.sh` script will attempt to verify the existence of a template named `logs`.
* In case the index template is absent, the script will attempt to generate a new one.