### PR TITLE
Hotfix 5.10.1

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,9 @@ if [ ! -z $OS_HOST ]; then
     export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
   fi
 
-  exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@" \
-    & exec /wait-for-it.sh $OS_HOST:$OS_PORT -t 0 -- ./index-template-setup.sh
+  /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@" \
+  & /wait-for-it.sh $OS_HOST:$OS_PORT -t 0 -- ./index-template-setup.sh \
+  ; wait
 
 else
 


### PR DESCRIPTION
In cases where the OpenSearch migration has been completed before the PostgreSQL migration as a parent process, the situation should be handled appropriately and waiting for the completion of the PostgreSQL migration.