### PR TITLE
Fix multi-platform build for golang-migrate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM --platform=${BUILDPLATFORM} alpine:latest
+ARG TARGETOS
+ARG TARGETARCH
+ARG GO_MIGRATE_VERSION="v4.17.1"
 ENV POSTGRES_SSLMODE="disable"
 RUN apk --no-cache add curl bash && \
-    curl -L https://github.com/golang-migrate/migrate/releases/download/v4.15.2/migrate.linux-amd64.tar.gz | tar xvz &&  \
+    curl -L https://github.com/golang-migrate/migrate/releases/download/${GO_MIGRATE_VERSION}/migrate.${TARGETOS}-${TARGETARCH}.tar.gz | tar xvz &&  \
     mv migrate /usr/local/bin/migrate && \
     chmod +x /usr/local/bin/migrate
 ADD "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" /wait-for-it.sh


### PR DESCRIPTION
Two new arguments, `TARGETOS` and `TARGETARCH`, were added for different build variations. Moreover, the going-migrate version is separated from the URL to the argument `GO_MIGRATE_VERSION` for easy maintaining.