### PR TITLE
Add user email migration scripts

### DIFF
--- a/migrations/205_update_default_user_emails.down.sql
+++ b/migrations/205_update_default_user_emails.down.sql
@@ -1,0 +1,7 @@
+UPDATE users
+SET email = 
+    CASE login
+        WHEN 'superadmin' THEN 'superadminemail@domain.com'
+        WHEN 'default' THEN 'defaultemail@domain.com'
+    END
+WHERE login IN ('superadmin', 'default');

--- a/migrations/205_update_default_user_emails.up.sql
+++ b/migrations/205_update_default_user_emails.up.sql
@@ -1,0 +1,7 @@
+UPDATE users
+SET email = 
+    CASE login
+        WHEN 'superadmin' THEN 'superadmin@example.com'
+        WHEN 'default' THEN 'default@example.com'
+    END
+WHERE login IN ('superadmin', 'default');

--- a/migrations/206_email_migration_to_login.down.sql
+++ b/migrations/206_email_migration_to_login.down.sql
@@ -1,0 +1,2 @@
+UPDATE users SET login = login_backup;
+ALTER TABLE users DROP COLUMN IF EXISTS login_backup;

--- a/migrations/206_email_migration_to_login.up.sql
+++ b/migrations/206_email_migration_to_login.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS login_backup VARCHAR(255) DEFAULT NULL;
+UPDATE users SET login_backup = login;
+UPDATE users SET login = email;


### PR DESCRIPTION
This pull request introduces two database migrations to update user email defaults and migrate the `login` column to use email values while preserving the original `login` data. The changes ensure a smooth transition of user data and maintain data integrity during the migration.

### Updates to default user emails:
* [`migrations/205_update_default_user_emails.up.sql`](diffhunk://#diff-1cddeb92a96a3747111e2d1acf31814f7a883dde9cac77015444f4612d790d0bR1-R7): Updates the `email` field for specific users (`superadmin` and `default`) to new default values (`superadmin@example.com` and `default@example.com`).
* [`migrations/205_update_default_user_emails.down.sql`](diffhunk://#diff-4fbbbb946b479ecd8b178c9fdc608b9ac853aaeea490d0766aba11b7ed368f49R1-R7): Reverts the `email` field for the same users to their previous values (`superadminemail@domain.com` and `defaultemail@domain.com`).

### Migration of `login` to email:
* [`migrations/206_email_migration_to_login.up.sql`](diffhunk://#diff-4232099abb4b09565d7697ecb1d35651be1de774ab0f0e6d7eb88100cad5f09cR1-R3): Adds a `login_backup` column to store current `login` values, then updates the `login` column to use the `email` values.
* [`migrations/206_email_migration_to_login.down.sql`](diffhunk://#diff-1da82fc46926ac0b477f3adff8501f7e3e7dba69cc78c20a0e488eb887386a4aR1-R2): Restores the original `login` values from the `login_backup` column and removes the `login_backup` column.