### PR TITLE
Fix email migrations

### DIFF
--- a/migrations/196_update_default_user_emails.up.sql
+++ b/migrations/196_update_default_user_emails.up.sql
@@ -1,7 +1,7 @@
 UPDATE users
 SET email = 
     CASE login
-        WHEN 'superadmin' THEN 'superadmin@example.com'
-        WHEN 'default' THEN 'default@example.com'
+        WHEN 'superadmin' THEN 'admin@reportportal.internal'
+        WHEN 'default' THEN 'default@reportportal.internal'
     END
 WHERE login IN ('superadmin', 'default');


### PR DESCRIPTION
This pull request updates the default email addresses for specific user logins in the database migration script to align with internal domain standards.

Database migration changes:

* [`migrations/196_update_default_user_emails.up.sql`](diffhunk://#diff-55b499647db14c1109ff9dfe9d7a0518f17875ac233d8126d82049fb2d7bc7c7L4-R5): Updated the email addresses for the `superadmin` and `default` user logins to use the `@reportportal.internal` domain instead of `@example.com`.