### PR TITLE
Feature orgs groups

### DIFF
--- a/migrations/206_add_org_id_to_groups.down.sql
+++ b/migrations/206_add_org_id_to_groups.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups DROP COLUMN IF EXISTS org_id;

--- a/migrations/206_add_org_id_to_groups.up.sql
+++ b/migrations/206_add_org_id_to_groups.up.sql
@@ -2,5 +2,5 @@ ALTER TABLE groups
     ADD COLUMN org_id INTEGER,
     ADD CONSTRAINT groups_org_id_fkey
     FOREIGN KEY (org_id)
-    REFERENCES organizations(id)
+    REFERENCES organization(id)
     ON DELETE CASCADE;

--- a/migrations/206_add_org_id_to_groups.up.sql
+++ b/migrations/206_add_org_id_to_groups.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE groups
+    ADD COLUMN org_id INTEGER,
+    ADD CONSTRAINT groups_org_id_fk
+    FOREIGN KEY (org_id)
+    REFERENCES organizations(id)
+    ON DELETE CASCADE;

--- a/migrations/206_add_org_id_to_groups.up.sql
+++ b/migrations/206_add_org_id_to_groups.up.sql
@@ -1,6 +1,6 @@
 ALTER TABLE groups
     ADD COLUMN org_id INTEGER,
-    ADD CONSTRAINT groups_org_id_fk
+    ADD CONSTRAINT groups_org_id_fkey
     FOREIGN KEY (org_id)
     REFERENCES organizations(id)
     ON DELETE CASCADE;

--- a/migrations/207_migrate_project_group_roles.down.sql
+++ b/migrations/207_migrate_project_group_roles.down.sql
@@ -1,0 +1,5 @@
+UPDATE groups_projects
+SET project_role = CASE 
+    WHEN project_role = 'EDITOR' THEN 'MEMBER'
+    ELSE 'OPERATOR'
+END;

--- a/migrations/207_migrate_project_group_roles.up.sql
+++ b/migrations/207_migrate_project_group_roles.up.sql
@@ -1,0 +1,5 @@
+UPDATE groups_projects
+SET project_role = CASE 
+    WHEN project_role IN ('PROJECT_MANAGER', 'MEMBER', 'CUSTOMER') THEN 'EDITOR'
+    ELSE 'VIEWER'
+END;


### PR DESCRIPTION
This pull request introduces two database migrations to update the schema and data for group and project roles. The most important changes include adding a new `org_id` column to the `groups` table with a foreign key constraint and updating the `project_role` values in the `groups_projects` table to align with new role definitions.

### Schema updates:
* [`migrations/206_add_org_id_to_groups.up.sql`](diffhunk://#diff-39ca8617e2ee41f10007400bf5513c305cd863f0d8b8933caa09afade696b615R1-R6): Added a new `org_id` column to the `groups` table, along with a foreign key constraint referencing the `organization` table. The foreign key ensures referential integrity and cascades deletions.
* [`migrations/206_add_org_id_to_groups.down.sql`](diffhunk://#diff-9f08e0dabf4a5cfffd93e6d3d94c1f95d63b20b0fd62c53c5eb78a4c7ea45935R1): Added a rollback operation to drop the `org_id` column from the `groups` table if it exists.

### Data updates:
* [`migrations/207_migrate_project_group_roles.up.sql`](diffhunk://#diff-9d1cfce1034ba528578e81be77f8b5ff8e29289ff7ac73959f02f763eb9f7f55R1-R5): Updated the `project_role` values in the `groups_projects` table. Roles like `PROJECT_MANAGER`, `MEMBER`, and `CUSTOMER` are consolidated into `EDITOR`, while others are mapped to `VIEWER`.
* [`migrations/207_migrate_project_group_roles.down.sql`](diffhunk://#diff-982a4f634da17b184619ae87e9fabde0688bb3313e8c098544d108d3ad00ff51R1-R5): Added a rollback operation to revert the `project_role` values back to their previous definitions.