### PR TITLE
Add migration scripts for unique group slug constraints

### DIFF
--- a/migrations/208_unique_group_slug_by_org.down.sql
+++ b/migrations/208_unique_group_slug_by_org.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE groups
+    DROP CONSTRAINT groups_slug_org_id_key,
+    ADD CONSTRAINT groups_slug_key UNIQUE (slug);

--- a/migrations/208_unique_group_slug_by_org.up.sql
+++ b/migrations/208_unique_group_slug_by_org.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE groups
+    DROP CONSTRAINT groups_slug_key,
+    ADD CONSTRAINT groups_slug_org_id_key UNIQUE (slug, org_id);


### PR DESCRIPTION
This pull request modifies the uniqueness constraints on the `groups` table to change how `slug` values are enforced as unique, depending on the organization context. The changes include updates to both the "up" and "down" migration files.

Migration changes:

* [`migrations/208_unique_group_slug_by_org.up.sql`](diffhunk://#diff-5e8bc456adbafdc490b8525e17acc70ac03f5c9f5573b80eb9a553984313d2c1R1-R3): Updated the migration to enforce `slug` uniqueness in combination with `org_id` by adding the `groups_slug_org_id_key` constraint and dropping the previous `groups_slug_key` constraint.
* [`migrations/208_unique_group_slug_by_org.down.sql`](diffhunk://#diff-ceefbd43b3949434690b5fe13b4607eae434f05c4ccc81d33370d0977b9d6982R1-R3): Updated the rollback migration to revert the changes by dropping the `groups_slug_org_id_key` constraint and restoring the original `groups_slug_key` constraint that enforces `slug` uniqueness globally.