### PR TITLE
Uniqueness for external_id

### DIFF
--- a/migrations/213_add_unique_external_id.down.sql
+++ b/migrations/213_add_unique_external_id.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE users DROP CONSTRAINT users_external_id_key;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_external_id_key;

--- a/migrations/213_add_unique_external_id.down.sql
+++ b/migrations/213_add_unique_external_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP CONSTRAINT users_external_id_unique;

--- a/migrations/213_add_unique_external_id.down.sql
+++ b/migrations/213_add_unique_external_id.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE users DROP CONSTRAINT users_external_id_unique;
+ALTER TABLE users DROP CONSTRAINT users_external_id_key;

--- a/migrations/213_add_unique_external_id.up.sql
+++ b/migrations/213_add_unique_external_id.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD CONSTRAINT users_external_id_unique UNIQUE (external_id);

--- a/migrations/213_add_unique_external_id.up.sql
+++ b/migrations/213_add_unique_external_id.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE users ADD CONSTRAINT users_external_id_unique UNIQUE (external_id);
+ALTER TABLE users ADD CONSTRAINT users_external_id_key UNIQUE (external_id);

--- a/migrations/213_add_unique_external_id.up.sql
+++ b/migrations/213_add_unique_external_id.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE users ADD CONSTRAINT users_external_id_key UNIQUE (external_id);
+ALTER TABLE users ADD CONSTRAINT IF NOT EXISTS users_external_id_key UNIQUE (external_id);


### PR DESCRIPTION
This pull request introduces a database migration to enforce uniqueness on the `external_id` column in the `users` table. The changes include adding and removing the corresponding constraint in the `up` and `down` migration files.

Database migration changes:

* [`migrations/213_add_unique_external_id.up.sql`](diffhunk://#diff-7a54a3917e7aa03ed2bfa31271bc2c6acb4dc8864800e5848f401c9d74f2b290R1): Added a unique constraint (`users_external_id_key`) to the `external_id` column in the `users` table.
* [`migrations/213_add_unique_external_id.down.sql`](diffhunk://#diff-f67f83a67c080cdf0eafefa0b79bb4ef762dd654b6937def2fb6c70cab1b3122R1): Dropped the unique constraint (`users_external_id_key`) from the `external_id` column in the `users` table.