### PR TITLE
Remove 'IF NOT EXISTS' from unique constraint on external_id in users…

### DIFF
--- a/migrations/213_add_unique_external_id.up.sql
+++ b/migrations/213_add_unique_external_id.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE users ADD CONSTRAINT IF NOT EXISTS users_external_id_key UNIQUE (external_id);
+ALTER TABLE users ADD CONSTRAINT users_external_id_key UNIQUE (external_id);


### PR DESCRIPTION
This pull request includes a small change to the `migrations/213_add_unique_external_id.up.sql` file. The change removes the `IF NOT EXISTS` clause from the `ADD CONSTRAINT`.
Reason: syntax error at or near "NOT" (column 37) in line 1: ALTER TABLE users ADD CONSTRAINT IF NOT EXISTS users_external_id_key UNIQUE (external_id); (details: pq: syntax error at or near "NOT")