### PR TITLE
Remove OS index creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 ARG TARGETOS
 ARG TARGETARCH
-ARG GO_MIGRATE_VERSION="v4.18.2"
+ARG GO_MIGRATE_VERSION="v4.18.3"
 ENV POSTGRES_SSLMODE="disable"
 RUN apk --no-cache add curl bash && \
     curl -L https://github.com/golang-migrate/migrate/releases/download/${GO_MIGRATE_VERSION}/migrate.${TARGETOS}-${TARGETARCH}.tar.gz | tar xvz &&  \
@@ -9,8 +9,7 @@ RUN apk --no-cache add curl bash && \
     chmod +x /usr/local/bin/migrate
 ADD "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" /wait-for-it.sh
 COPY entrypoint.sh /entrypoint.sh
-COPY index-template-setup.sh /index-template-setup.sh
-RUN chmod +x /entrypoint.sh && chmod +xr /wait-for-it.sh && chmod +x /index-template-setup.sh
+RUN chmod +x /entrypoint.sh && chmod +xr /wait-for-it.sh
 COPY migrations/ /migrations/
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["up"]

--- a/README.md
+++ b/README.md
@@ -41,8 +41,3 @@ docker-compose run --rm migrations down N
 |POSTGRES_PASSWORD|Postgres password|
 |POSTGRES_SERVER|Postgres server|
 |POSTGRES_DB|Postgres database|
-|OS_HOST|Opensearch host. You might keep this field empty if you use Elasticsearch|
-|OS_PORT|Opensearch port|
-|OS_PROTOCOL|Opensearch protocol. If security plugin is enabled, use https|
-|OS_USER|Opensearch user. If the security plugin is disabled, keep it empty|
-|OS_PASSWORD|Opensearch password. If the security plugin is disabled, keep it empty|

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,7 @@
 #!/bin/sh
 
-if [ ! -z $OS_HOST ]; then
-
-  if [ ! -z $POSTGRES_PASSWORD_FILE ]; then
-    export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
-  fi
-
-  /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@" \
-  & /wait-for-it.sh $OS_HOST:$OS_PORT -t 0 -- ./index-template-setup.sh \
-  ; wait
-
-else
-
-  if [ ! -z $POSTGRES_PASSWORD_FILE ]; then
-    export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
-  fi
-
-  exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@"
-
+if [ ! -z $POSTGRES_PASSWORD_FILE ]; then
+  export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
 fi
+
+exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@"

--- a/index-template-setup.sh
+++ b/index-template-setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Uses for creating an index template in OpenSearch for cases 
+# when ReportPortal stores logs in a data stream.
+
 # Index template name
 TEMPLATE_NAME="logs"
 


### PR DESCRIPTION
This pull request simplifies the Docker setup by removing OpenSearch-related configurations and dependencies, while also updating the `GO_MIGRATE_VERSION` to its latest patch. Below are the key changes grouped by theme:

### OpenSearch-related cleanup:
* Removed OpenSearch-related environment variables from `README.md`, including `OS_HOST`, `OS_PORT`, `OS_PROTOCOL`, `OS_USER`, and `OS_PASSWORD`.
* Deleted OpenSearch-specific logic from `entrypoint.sh`, including the execution of `index-template-setup.sh` and related checks.
* Removed the `index-template-setup.sh` script from the `Dockerfile` and its execution during the container build process.

### Dependency updates:
* Updated `GO_MIGRATE_VERSION` in the `Dockerfile` from `v4.18.2` to `v4.18.3` to use the latest patch version.

### Miscellaneous:
* Added comments to `index-template-setup.sh` to clarify its purpose for creating an index template in OpenSearch.…sh and clean up README