### PR TITLE
EPMRPP-109804 || Update golang-migrate version to v4.19.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 ARG TARGETOS
 ARG TARGETARCH
-ARG GO_MIGRATE_VERSION="v4.18.3"
+ARG GO_MIGRATE_VERSION="v4.19.0"
 ENV POSTGRES_SSLMODE="disable"
 RUN apk --no-cache add curl bash && \
     curl -L https://github.com/golang-migrate/migrate/releases/download/${GO_MIGRATE_VERSION}/migrate.${TARGETOS}-${TARGETARCH}.tar.gz | tar xvz &&  \


### PR DESCRIPTION
This pull request updates the version of the `golang-migrate` tool used in the `Dockerfile`. The only change is bumping the `GO_MIGRATE_VERSION` from `v4.18.3` to `v4.19.0` to ensure the latest migration features and fixes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated golang-migrate to v4.19.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->