### PR TITLE
Add number column to tms_manual_scenario_requirement for ordering

### DIFF
--- a/migrations/1000_tms_initial.up.sql
+++ b/migrations/1000_tms_initial.up.sql
@@ -326,7 +326,8 @@ CREATE TABLE tms_manual_scenario_requirement
     value              VARCHAR(255),
     manual_scenario_id BIGINT       NOT NULL
         CONSTRAINT tms_manual_scenario_requirement_fk_manual_scenario
-            REFERENCES tms_manual_scenario
+            REFERENCES tms_manual_scenario,
+    number             INTEGER      NOT NULL DEFAULT 0
 );
 
 CREATE INDEX idx_tms_manual_scenario_requirement_scenario_id


### PR DESCRIPTION
## Summary

Adds a `number` column (INTEGER NOT NULL DEFAULT 0) to the `tms_manual_scenario_requirement` table to support preserving the order of requirements as they are sent via the API.

## Changes

### Migration
- **1001_tms_requirement_number.up.sql**: Adds `number INTEGER NOT NULL DEFAULT 0` column to `tms_manual_scenario_requirement`
- **1001_tms_requirement_number.down.sql**: Drops the `number` column

## Backward Compatibility
- All existing rows will get `number = 0` via the DEFAULT clause, ensuring backward compatibility
- The column follows the same pattern as `tms_step.number` which is already used for step ordering

## Related
- Companion PR in `report-portal-service-api` implements the application-level ordering logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Test Management System now available with comprehensive lifecycle support: organize test cases in hierarchies, create and manage test plans, define manual test scenarios, track execution results across environments, manage datasets and product versions, and collaborate through execution comments and attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->