### PR TITLE
EPMRPP-115901: URL-encode database credentials in entrypoint

### DIFF
--- a/.github/workflows/build-feature-image.yaml
+++ b/.github/workflows/build-feature-image.yaml
@@ -19,7 +19,7 @@ jobs:
     if: (!startsWith(github.head_ref, 'rc/') || !startsWith(github.head_ref, 'hotfix/') || !startsWith(github.head_ref, 'master') || !startsWith(github.head_ref, 'main'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Create variables
         id: vars

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,42 @@
 #!/bin/sh
 
+# writing this in sh so we don't need to install extra dependencies.
+urlencode() {
+    old_lc_collate=$LC_COLLATE
+    LC_COLLATE=C
+
+    local length="${#1}"
+    i=0
+    while [ $i -lt $length ]; do
+        c="$(expr substr "$1" $((i + 1)) 1)"
+        case $c in
+            [a-zA-Z0-9.~_-]) printf "%s" "$c" ;;
+            *) printf '%%%02X' "'$c" ;;
+        esac
+        i=$((i + 1))
+    done
+
+    LC_COLLATE=$old_lc_collate
+}
+
+
 if [ ! -z $POSTGRES_PASSWORD_FILE ]; then
   export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
+fi
+
+ENCODED_PASSWORD=$(urlencode $POSTGRES_PASSWORD)
+ENCODED_USER=$(urlencode $POSTGRES_USER)
+
+if [ ! -z $OS_HOST ]; then
+
+  /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$ENCODED_USER:$ENCODED_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@" \
+  & /wait-for-it.sh $OS_HOST:$OS_PORT -t 0 -- ./index-template-setup.sh \
+  ; wait
+
+else
+
+  exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$ENCODED_USER:$ENCODED_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@"
+
 fi
 
 exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,29 +5,27 @@ urlencode() {
     old_lc_collate=$LC_COLLATE
     LC_COLLATE=C
 
-    local length="${#1}"
-    i=0
-    while [ $i -lt $length ]; do
-        c="$(expr substr "$1" $((i + 1)) 1)"
-        case $c in
-            [a-zA-Z0-9.~_-]) printf "%s" "$c" ;;
-            *) printf '%%%02X' "'$c" ;;
+    _ue_str="$1"
+    while [ -n "$_ue_str" ]; do
+        _ue_c="${_ue_str%"${_ue_str#?}"}"
+        _ue_str="${_ue_str#?}"
+        case $_ue_c in
+            [a-zA-Z0-9.~_-]) printf "%s" "$_ue_c" ;;
+            *) printf '%%%02X' "'$_ue_c" ;;
         esac
-        i=$((i + 1))
     done
 
     LC_COLLATE=$old_lc_collate
 }
 
-
-if [ ! -z $POSTGRES_PASSWORD_FILE ]; then
-  export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
+if [ -n "$POSTGRES_PASSWORD_FILE" ]; then
+  export POSTGRES_PASSWORD=$(cat "$POSTGRES_PASSWORD_FILE")
 fi
 
-ENCODED_PASSWORD=$(urlencode $POSTGRES_PASSWORD)
-ENCODED_USER=$(urlencode $POSTGRES_USER)
+ENCODED_PASSWORD=$(urlencode "$POSTGRES_PASSWORD")
+ENCODED_USER=$(urlencode "$POSTGRES_USER")
 
-if [ ! -z $OS_HOST ]; then
+if [ -n "$OS_HOST" ]; then
 
   /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$ENCODED_USER:$ENCODED_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@" \
   & /wait-for-it.sh $OS_HOST:$OS_PORT -t 0 -- ./index-template-setup.sh \
@@ -38,5 +36,3 @@ else
   exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$ENCODED_USER:$ENCODED_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@"
 
 fi
-
-exec /wait-for-it.sh $POSTGRES_SERVER:$POSTGRES_PORT -t 0 -- migrate -path /migrations -database postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_SERVER:$POSTGRES_PORT/$POSTGRES_DB?sslmode=$POSTGRES_SSLMODE "$@"


### PR DESCRIPTION
## Summary

- URL-encode `POSTGRES_USER` and `POSTGRES_PASSWORD` before building the migrate connection string, fixing failures when credentials contain special characters (follow-up to #326 / #143).
- Harden `entrypoint.sh` for Alpine/BusyBox (`#!/bin/sh`): POSIX-portable `urlencode` loop, quoted variables, and `[ -n "$VAR" ]` guards.
- Remove the redundant final `exec` that ran migrate again with unencoded credentials when `OS_HOST` was set.
- Bump `actions/checkout` to v6 in the feature image workflow.

## Test plan

- [x] Build the migrations image and run with a Postgres password containing special characters (e.g. `@`, `#`, `%`, spaces).
- [x] Verify migrations complete successfully (`up` / `down` as applicable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions checkout action from v3 to v6 for Docker image builds.

* **Bug Fixes**
  * Database connection credentials are now properly URL-encoded.

* **New Features**
  * Added support for concurrent initialization of OS host components alongside database migration when enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/migrations/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->