### PR TITLE
EPMRPP-117062 || Update organization table schema to remove uniquenes

### DIFF
--- a/migrations/199_organization_tables.up.sql
+++ b/migrations/199_organization_tables.up.sql
@@ -3,14 +3,17 @@ CREATE TABLE organization
     id bigserial PRIMARY KEY,
     created_at TIMESTAMP DEFAULT now() NOT NULL,
     updated_at TIMESTAMP DEFAULT now() NOT NULL,
-    name TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
     organization_type TEXT NOT NULL,
     external_id TEXT UNIQUE,
-    slug TEXT NOT NULL UNIQUE,
+    slug TEXT NOT NULL,
     owner_id BIGINT UNIQUE REFERENCES users(id) ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS organization_slug_idx ON organization(slug);
+
+CREATE UNIQUE INDEX IF NOT EXISTS organization_name_lower_key ON organization (lower(name));
+CREATE UNIQUE INDEX IF NOT EXISTS organization_slug_lower_key ON organization (lower(slug));
 
 CREATE TYPE ORGANIZATION_ROLE_ENUM AS ENUM ('MANAGER', 'MEMBER');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization names and slugs now enforce case-insensitive uniqueness, preventing duplicate entries that differ only by letter casing.
  * Existing organization slug lookups remain supported with the preserved index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->