### PR TITLE
EPMRPP-118672 & EPMRPP-118672: Increase tms_test_plan description and tms_manual_scenario preconditions length to 2048

### DIFF
--- a/migrations/1005_increase_tms_test_plan_description_length.down.sql
+++ b/migrations/1005_increase_tms_test_plan_description_length.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tms_test_plan ALTER COLUMN description TYPE varchar(255);

--- a/migrations/1005_increase_tms_test_plan_description_length.up.sql
+++ b/migrations/1005_increase_tms_test_plan_description_length.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tms_test_plan ALTER COLUMN description TYPE varchar(2048);

--- a/migrations/1006_increase_tms_manual_scenario_preconditions_length.down.sql
+++ b/migrations/1006_increase_tms_manual_scenario_preconditions_length.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tms_manual_scenario_preconditions ALTER COLUMN value TYPE varchar(255);

--- a/migrations/1006_increase_tms_manual_scenario_preconditions_length.up.sql
+++ b/migrations/1006_increase_tms_manual_scenario_preconditions_length.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tms_manual_scenario_preconditions ALTER COLUMN value TYPE varchar(2048);


### PR DESCRIPTION
**Description:**
Fixes 500 error on Test Plan creation when the description is longer than 255 symbols. The description field length in `tms_test_plan` table has been increased to 2048 symbols to match the application limits.

**Related Issue:**
[EPMRPP-118672](https://jiraeu.epam.com/browse/EPMRPP-118672)