### PR TITLE
Fix: Increase tms_attribute length to 512

### DIFF
--- a/migrations/216_tms_initial.up.sql
+++ b/migrations/216_tms_initial.up.sql
@@ -22,8 +22,8 @@ CREATE TABLE tms_attribute
 (
     id         BIGSERIAL
         CONSTRAINT tms_attribute_pk PRIMARY KEY,
-    key        varchar(255) NOT NULL,
-    value      varchar(255),
+    key        varchar(512) NOT NULL,
+    value      varchar(512),
     project_id bigint NOT NULL
         CONSTRAINT tms_attribute_fk_project
             REFERENCES project ON DELETE CASCADE,


### PR DESCRIPTION
Increase `tms_attribute` `key` and `value` length to 512 to fix 500 error on Test Plan creation with long attributes.

Fixes: [EPMRPP-118810](https://jiraeu.epam.com/browse/EPMRPP-118810)